### PR TITLE
fix thumbnail youtube

### DIFF
--- a/Classes/Feed/Update/BaseUpdater.php
+++ b/Classes/Feed/Update/BaseUpdater.php
@@ -204,8 +204,7 @@ abstract class BaseUpdater implements FeedUpdaterInterface
             $downloadFolder = $storage->getFolder($folderPath);
         }
 
-        $baseUrl = explode('?', basename($url), 2);
-        $filename = md5($baseUrl[0]);
+        $filename = md5($url);
 
         $file = $downloadFolder->getFile($filename);
         if ($file == null) {


### PR DESCRIPTION
die baseURL ist bei jedem Bild gleich (heißt immer /hqdefault.jpg oder so), daher wird nur einmal ein Bild erzeugt. Dabei ist aber die ganze url erst eindeutig. 